### PR TITLE
Rails8 and index is ASYNC

### DIFF
--- a/activerecord-dsql-adapter.gemspec
+++ b/activerecord-dsql-adapter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["README.md", "lib/**/*"]
 
-  spec.add_dependency "activerecord", ">= 7.2.0"
+  spec.add_dependency "activerecord", ">= 7.2.0", "< 9"
   spec.add_dependency "pg", "~> 1.1"
   spec.add_dependency "aws-sdk-dsql"
 end

--- a/activerecord-dsql-adapter.gemspec
+++ b/activerecord-dsql-adapter.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["README.md", "lib/**/*"]
 
-  spec.add_dependency "activerecord", "~> 7.2.0"
+  spec.add_dependency "activerecord", ">= 7.2.0"
   spec.add_dependency "pg", "~> 1.1"
   spec.add_dependency "aws-sdk-dsql"
 end

--- a/lib/active_record/connection_adapters/dsql/schema_statements.rb
+++ b/lib/active_record/connection_adapters/dsql/schema_statements.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module ConnectionAdapters
+    module DSQL
+      module SchemaStatements
+        def add_index_options(table_name, column_name, **options) # :nodoc:
+          options[:algorithm] = :async
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/active_record/connection_adapters/dsql_adapter.rb
+++ b/lib/active_record/connection_adapters/dsql_adapter.rb
@@ -10,6 +10,8 @@ module ActiveRecord
     class DSQLAdapter < PostgreSQLAdapter
       ADAPTER_NAME = "DSQL"
 
+      include ActiveRecord::ConnectionAdapters::DSQL::SchemaStatements
+
       class << self
         def new_client(conn_params)
           conn_params[:sslmode] ||= "require"
@@ -117,6 +119,10 @@ module ActiveRecord
       #
       def supports_ddl_transactions?
         false
+      end
+
+      def index_algorithms
+        { async: "ASYNC" }
       end
 
       # Ignore DSQL sys schema.

--- a/lib/activerecord-dsql-adapter.rb
+++ b/lib/activerecord-dsql-adapter.rb
@@ -12,6 +12,7 @@ module ActiveRecord
       extend ActiveSupport::Autoload
 
       autoload :SchemaDumper
+      autoload :SchemaStatements
     end
   end
 end


### PR DESCRIPTION
Allow Rails 8
Index creation is always ASYNC e.g. 
```
CREATE [ UNIQUE ] INDEX ASYNC [ IF NOT EXISTS ] name ON table_name ( { column_name } [ NULLS { FIRST | LAST } ] ) [ INCLUDE ( column_name [, ...] ) ] [ NULLS [ NOT ] DISTINCT ];
```
